### PR TITLE
arm: dts: qcom: msm8226: add msmgpio node

### DIFF
--- a/arch/arm/boot/dts/qcom-msm8226.dtsi
+++ b/arch/arm/boot/dts/qcom-msm8226.dtsi
@@ -99,6 +99,18 @@
 			#interrupt-cells = <3>;
 		};
 
+	msmgpio: gpio@fd510000 {
+		compatible = "qcom,msm-gpio";
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		reg = <0xfd510000 0x4000>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpio = <117>;
+		interrupts = <0 208 0>;
+		qcom,direct-connect-irqs = <8>;
+	};
+
 		apcs: syscon@f9011000 {
 			compatible = "syscon";
 			reg = <0xf9011000 0x1000>;


### PR DESCRIPTION
Add msmgpio node that is needed in order to support the WCNSS.
We can refer to the repair from DTB of XT1079.
https://GitHub.com/PAforMoto/android_kernel_motorola_msm8226/blob/nougat-mr2/arch/arm/boot/dts/msm8226.dtsi